### PR TITLE
feature: Support Webpack 5, add output dir cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,9 @@ class ManifestReplacePlugin {
             fs.mkdirSync(dir, {recursive: true});
           }
 
-          fs.writeFileSync(outputPath, source);
+          fs.writeFile(outputPath, source, err => {
+            if (err) console.error(err);
+		  });
         });
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import path from 'path';
 
+import fs from 'fs';
+
 import glob from 'glob';
+
 
 import { buildChunkMap, replaceSource } from './lib';
 
@@ -25,26 +28,22 @@ class ManifestReplacePlugin {
 
     compiler.hooks.emit.tap(pluginName, (compilation) => {
       const chunkMap = buildChunkMap(compilation);
-      const relativeTargetDir = options.outputDir
-        ? path.relative(compiler.options.output.path, options.outputDir)
-        : '';
-
+      const outputDir = options.outputDir
+        ? options.outputDir
+        : compiler.options.output.path
       glob
         .sync(path.join(options.include, '**/**'), { nodir: true })
         .filter((file) => options.test.test(path.basename(file)))
         .forEach((file) => {
           const source = replaceSource(file, chunkMap);
 
-          const assetKey = path.join(
-            relativeTargetDir,
-            path.relative(options.include, file)
-          );
+          const outputPath = path.join(outputDir, path.relative(options.include, file));
+          const dir = path.dirname(outputPath);
+          if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, {recursive: true});
+          }
 
-          // eslint-disable-next-line no-param-reassign
-          compilation.assets[assetKey] = {
-            source: () => source,
-            size: () => source.length,
-          };
+          fs.writeFileSync(outputPath, source);
         });
     });
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 
 export function buildChunkMap(compilation) {
-  const publicPath = compilation.mainTemplate.getPublicPath({
+  const publicPath = compilation.getAssetPath(compilation.outputOptions.publicPath, {
     hash: compilation.hash,
   });
 

--- a/test/cases/output-dir-case/expected/index.html
+++ b/test/cases/output-dir-case/expected/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+</head>
+<body>
+<script type="text/javascript" src="index-391ce5a8374ac3b1bf96.js"></script>
+</body>
+</html>

--- a/test/cases/output-dir-case/expected/output/output.html
+++ b/test/cases/output-dir-case/expected/output/output.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App Output Folder</title>
+</head>
+<body>
+<script type="text/javascript" src="index-391ce5a8374ac3b1bf96.js"></script>
+</body>
+</html>

--- a/test/cases/output-dir-case/index.html
+++ b/test/cases/output-dir-case/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+</head>
+<body>
+<script type="text/javascript" src="index.js"></script>
+</body>
+</html>

--- a/test/cases/output-dir-case/index.js
+++ b/test/cases/output-dir-case/index.js
@@ -1,0 +1,1 @@
+// document.write('Hello world!');

--- a/test/cases/output-dir-case/output/output.html
+++ b/test/cases/output-dir-case/output/output.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App Output Folder</title>
+</head>
+<body>
+<script type="text/javascript" src="index.js"></script>
+</body>
+</html>

--- a/test/cases/output-dir-case/webpack.config.js
+++ b/test/cases/output-dir-case/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+const ManifestReplacePlugin = require('../../../');
+
+module.exports = {
+  entry: {
+    'index': './index.js',
+  },
+  output: {
+    publicPath: '',
+    filename: '[name]-[chunkhash].js',
+  },
+  plugins: [
+    new ManifestReplacePlugin({
+      include: path.resolve(__dirname),
+	  outputDir: path.join(__dirname, '../../js/output-dir-case')
+    }),
+  ]
+};

--- a/test/webpack-manifest-replace-plugin.test.js
+++ b/test/webpack-manifest-replace-plugin.test.js
@@ -4,6 +4,20 @@ const fs = require('fs');
 
 const webpack = require('webpack');
 
+const recursiveFileRead = (expectedDir, outputDir, relativeDir) => {
+  fs.readdirSync(expectedDir).forEach((expectedFile) => {
+    const filePath = path.resolve(expectedDir, expectedFile)
+    if (fs.lstatSync(filePath).isDirectory()) {
+      recursiveFileRead(filePath, outputDir, path.relative(expectedDir, filePath))
+      return;
+    }
+    const expected = fs.readFileSync(filePath, 'utf8');
+    const actual = fs.readFileSync(path.resolve(path.join(outputDir, relativeDir), expectedFile), 'utf8');
+
+    assert.strictEqual(actual, expected);
+  });
+}
+
 describe('Tests', () => {
   fs.readdirSync(path.join(__dirname, 'cases')).forEach((testCase) => {
     it(testCase, () => {
@@ -26,13 +40,9 @@ describe('Tests', () => {
         }
 
         const expectedDir = path.join(testDir, 'expected');
-        fs.readdirSync(expectedDir).forEach((expectedFile) => {
-          const expected = fs.readFileSync(path.resolve(expectedDir, expectedFile), 'utf8');
-          const actual = fs.readFileSync(path.resolve(outputDir, expectedFile), 'utf8');
-
-          assert.strictEqual(actual, expected);
-        });
+		recursiveFileRead(expectedDir, outputDir, '.');
       });
     });
   })
 });
+


### PR DESCRIPTION
https://github.com/unchai/webpack-manifest-replace-plugin/pull/11

This PR is related to above one.

- remove compilation.mainTemplate.getPublicPath
- remove to set compilation.assets[assetKey] directly.
- add test case for specific outputDir case. 